### PR TITLE
chore: use default exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "inquirer": "^6.2.1",
     "kleur": "^3.0.3",
     "mkdirp": "^1.0.3",
-    "node-banner": "^1.3.2",
+    "node-banner": "^1.4.0",
     "ora": "^4.0.3"
   },
   "devDependencies": {

--- a/src/commands/scaffold.ts
+++ b/src/commands/scaffold.ts
@@ -1,11 +1,11 @@
 'use strict';
 
-import * as execa from 'execa';
-import * as fs from 'fs';
-import * as inquirer from 'inquirer';
-import * as ora from 'ora';
-import * as path from 'path';
-import showBanner = require('node-banner');
+import execa from 'execa';
+import fs from 'fs';
+import inquirer from 'inquirer';
+import ora from 'ora';
+import path from 'path';
+import showBanner from 'node-banner';
 
 import * as logger from '../utils/logger';
 import { hasYarn } from '../utils/validate';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
       ],
      "module": "commonjs",
      "outDir": "./lib",
+     "esModuleInterop": true,
      "sourceMap": false,
      "strict": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,7 +2619,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-banner@^1.3.2:
+node-banner@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/node-banner/-/node-banner-1.4.0.tgz#f73ebe9931831149fbf79ff5f97644649284be3d"
   integrity sha512-aoePRR7TaaG5LORQkpjsdFaELgVAeRdgaumIQNVWosIhWslCx1kFSlssSPbqvuWp+N5wtS8Wk+qzfAM7IqR3ZQ==


### PR DESCRIPTION
- Use default exports.
- Bump `node-banner`.