### PR TITLE
chore: update funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,3 @@
 ko_fi: jamesgeorge007
-open_collective: jamesgeorge007
 patreon: jamesgeorge007
 custom: https://www.paypal.me/jamesgeorge007


### PR DESCRIPTION
Removed `open-collective`.